### PR TITLE
remove N=1 check when decoding a literal field line with name reference

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -196,7 +196,7 @@ func (d *Decoder) parseIndexedHeaderField() error {
 
 func (d *Decoder) parseLiteralHeaderField() error {
 	buf := d.buf
-	if buf[0]&0x20 > 0 || buf[0]&0x10 == 0 {
+	if buf[0]&0x10 == 0 {
 		return errNoDynamicTable
 	}
 	index, buf, err := readVarInt(4, buf)

--- a/decoder.go
+++ b/decoder.go
@@ -199,6 +199,10 @@ func (d *Decoder) parseLiteralHeaderField() error {
 	if buf[0]&0x10 == 0 {
 		return errNoDynamicTable
 	}
+	// We don't need to check the value of the N-bit here.
+	// It's only relevant when re-encoding header fields,
+	// and determines whether the header field can be added to the dynamic table.
+	// Since we don't support the dynamic table, we can ignore it.
 	index, buf, err := readVarInt(4, buf)
 	if err != nil {
 		return err

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -119,9 +119,21 @@ func TestDecoderInvalidIndexedHeaderFields(t *testing.T) {
 }
 
 func TestDecoderLiteralHeaderFieldWithNameReference(t *testing.T) {
+	t.Run("without the N-bit", func(t *testing.T) {
+		testDecoderLiteralHeaderFieldWithNameReference(t, false)
+	})
+	t.Run("with the N-bit", func(t *testing.T) {
+		testDecoderLiteralHeaderFieldWithNameReference(t, true)
+	})
+}
+
+func testDecoderLiteralHeaderFieldWithNameReference(t *testing.T, n bool) {
 	decoder := newRecordingDecoder()
 	data := appendVarInt(nil, 4, 49)
 	data[0] ^= 0x40 | 0x10
+	if n {
+		data[0] |= 0x20
+	}
 	data = appendVarInt(data, 7, 6)
 	data = append(data, []byte("foobar")...)
 	doPartialWrites(t, decoder, insertPrefix(data))


### PR DESCRIPTION
Fixes #51.

This field is only used to determine if the dynamic table can be used when this field is re-encoded. Since we currently don't support use of the dynamic table, the N value is irrelevant.

@DineshAdhi @kixcord Could you take a quick look at this PR?