### PR TITLE
ci: remove 386 (32 bit x86)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,6 @@ jobs:
       - run: go version
       - name: Run tests
         run: go test -v -cover -race -shuffle=on .
-      - name: Run tests (32 bit)
-        env:
-          GOARCH: 386
-        run: go test -v -cover -coverprofile=coverage.txt -shuffle=on .
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
As suggested by @MarcoPolo in https://github.com/quic-go/quic-go/pull/5352.