### PR TITLE
Add decoder-side dynamic table support

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -4,25 +4,128 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	"golang.org/x/net/http2/hpack"
 )
 
 // An invalidIndexError is returned when decoding encounters an invalid index
-// (e.g., an index that is out of bounds for the static table).
+// (e.g., an index that is out of bounds for the static or dynamic table).
 type invalidIndexError int
 
 func (e invalidIndexError) Error() string {
 	return fmt.Sprintf("invalid indexed representation index %d", int(e))
 }
 
-var errNoDynamicTable = errors.New("no dynamic table")
+var (
+	errInvalidTableIndex  = errors.New("invalid dynamic table index")
+	errTableCapacityLimit = errors.New("dynamic table capacity exceeded")
+)
+
+// dynamicTable represents the QPACK dynamic table.
+// It's a FIFO queue where new entries are added at the front (index 0)
+// and old entries are evicted from the back when capacity is exceeded.
+type dynamicTable struct {
+	entries     []HeaderField
+	size        uint64 // current size in bytes
+	capacity    uint64 // maximum capacity in bytes
+	insertCount uint64 // total number of entries ever inserted (for absolute indexing)
+}
+
+// newDynamicTable creates a new dynamic table with the given capacity.
+func newDynamicTable(capacity uint64) *dynamicTable {
+	return &dynamicTable{
+		entries:  make([]HeaderField, 0, 64),
+		capacity: capacity,
+	}
+}
+
+// setCapacity sets the maximum capacity of the dynamic table.
+// If the new capacity is smaller, entries are evicted.
+func (dt *dynamicTable) setCapacity(capacity uint64) {
+	dt.capacity = capacity
+	dt.evict()
+}
+
+// insert adds a new entry to the dynamic table.
+// Returns the absolute index of the inserted entry.
+func (dt *dynamicTable) insert(hf HeaderField) uint64 {
+	entrySize := headerFieldSize(hf)
+
+	// Evict entries if needed to make room
+	for dt.size+entrySize > dt.capacity && len(dt.entries) > 0 {
+		// Remove from back (oldest entry)
+		last := dt.entries[len(dt.entries)-1]
+		dt.entries = dt.entries[:len(dt.entries)-1]
+		dt.size -= headerFieldSize(last)
+	}
+
+	// If entry is too large for table, don't insert but still increment count
+	if entrySize > dt.capacity {
+		dt.insertCount++
+		return dt.insertCount - 1
+	}
+
+	// Insert at front (newest entry)
+	dt.entries = append([]HeaderField{hf}, dt.entries...)
+	dt.size += entrySize
+	dt.insertCount++
+
+	return dt.insertCount - 1
+}
+
+// evict removes entries until size <= capacity
+func (dt *dynamicTable) evict() {
+	for dt.size > dt.capacity && len(dt.entries) > 0 {
+		last := dt.entries[len(dt.entries)-1]
+		dt.entries = dt.entries[:len(dt.entries)-1]
+		dt.size -= headerFieldSize(last)
+	}
+}
+
+// atRelative returns the entry at a relative index (0 = most recent).
+func (dt *dynamicTable) atRelative(relIndex uint64) (HeaderField, bool) {
+	if relIndex >= uint64(len(dt.entries)) {
+		return HeaderField{}, false
+	}
+	return dt.entries[relIndex], true
+}
+
+// atAbsolute returns the entry at an absolute index.
+// Absolute index = insertCount at time of insertion.
+func (dt *dynamicTable) atAbsolute(absIndex uint64) (HeaderField, bool) {
+	if absIndex >= dt.insertCount {
+		return HeaderField{}, false
+	}
+	// Convert absolute to relative
+	// relIndex = insertCount - 1 - absIndex
+	relIndex := dt.insertCount - 1 - absIndex
+	return dt.atRelative(relIndex)
+}
+
+// atPostBase returns the entry at a post-base index.
+// Post-base indices are used for entries inserted after the base.
+func (dt *dynamicTable) atPostBase(base, postBaseIndex uint64) (HeaderField, bool) {
+	absIndex := base + postBaseIndex
+	return dt.atAbsolute(absIndex)
+}
+
+// headerFieldSize returns the size of a header field as defined by QPACK.
+// Size = len(name) + len(value) + 32
+func headerFieldSize(hf HeaderField) uint64 {
+	return uint64(len(hf.Name) + len(hf.Value) + 32)
+}
 
 // A Decoder decodes QPACK header blocks.
 // A Decoder can be reused to decode multiple header blocks on different streams
 // on the same connection (e.g., headers then trailers).
-// This will be useful when dynamic table support is added.
-type Decoder struct{}
+type Decoder struct {
+	dynTable *dynamicTable
+	mu       sync.RWMutex
+
+	// maxTableCapacity is the maximum capacity we'll accept
+	maxTableCapacity uint64
+}
 
 // DecodeFunc is a function that decodes the next header field from a header block.
 // It should be called repeatedly until it returns io.EOF.
@@ -30,9 +133,188 @@ type Decoder struct{}
 // Any error other than io.EOF indicates a decoding error.
 type DecodeFunc func() (HeaderField, error)
 
-// NewDecoder returns a new Decoder.
+// NewDecoder returns a new Decoder with dynamic table support.
 func NewDecoder() *Decoder {
-	return &Decoder{}
+	return &Decoder{
+		dynTable:         newDynamicTable(0),
+		maxTableCapacity: 65536, // Default max capacity
+	}
+}
+
+// NewDecoderWithCapacity returns a new Decoder with the given max table capacity.
+func NewDecoderWithCapacity(maxCapacity uint64) *Decoder {
+	return &Decoder{
+		dynTable:         newDynamicTable(maxCapacity),
+		maxTableCapacity: maxCapacity,
+	}
+}
+
+// SetDynamicTableCapacity processes a Set Dynamic Table Capacity instruction.
+func (d *Decoder) SetDynamicTableCapacity(capacity uint64) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if capacity > d.maxTableCapacity {
+		return errTableCapacityLimit
+	}
+	d.dynTable.setCapacity(capacity)
+	return nil
+}
+
+// InsertCount returns the current insert count of the dynamic table.
+func (d *Decoder) InsertCount() uint64 {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.dynTable.insertCount
+}
+
+// ProcessEncoderInstructions processes instructions from the encoder stream.
+// This should be called with data received on the QPACK encoder stream.
+func (d *Decoder) ProcessEncoderInstructions(data []byte) error {
+	for len(data) > 0 {
+		b := data[0]
+		var err error
+
+		switch {
+		case b&0x80 > 0:
+			// Insert With Name Reference
+			// 1Txxxxxx - T=1 for static, T=0 for dynamic
+			if b&0x40 > 0 {
+				data, err = d.processInsertWithStaticNameRef(data)
+			} else {
+				data, err = d.processInsertWithDynamicNameRef(data)
+			}
+		case b&0x40 > 0:
+			// Insert Without Name Reference
+			// 01xxxxxx
+			data, err = d.processInsertWithoutNameRef(data)
+		case b&0x20 > 0:
+			// Set Dynamic Table Capacity
+			// 001xxxxx
+			data, err = d.processSetCapacity(data)
+		default:
+			// Duplicate
+			// 000xxxxx
+			data, err = d.processDuplicate(data)
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *Decoder) processInsertWithStaticNameRef(buf []byte) ([]byte, error) {
+	// 1 1 xxxxxx - static table reference
+	nameIndex, rest, err := readVarInt(6, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read value
+	if len(rest) == 0 {
+		return nil, io.ErrUnexpectedEOF
+	}
+	usesHuffman := rest[0]&0x80 > 0
+	value, rest, err := d.readString(rest, 7, usesHuffman)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get name from static table
+	if nameIndex >= uint64(len(staticTableEntries)) {
+		return nil, invalidIndexError(nameIndex)
+	}
+	name := staticTableEntries[nameIndex].Name
+
+	d.mu.Lock()
+	d.dynTable.insert(HeaderField{Name: name, Value: value})
+	d.mu.Unlock()
+	return rest, nil
+}
+
+func (d *Decoder) processInsertWithDynamicNameRef(buf []byte) ([]byte, error) {
+	// 1 0 xxxxxx - dynamic table reference
+	nameIndex, rest, err := readVarInt(6, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read value
+	if len(rest) == 0 {
+		return nil, io.ErrUnexpectedEOF
+	}
+	usesHuffman := rest[0]&0x80 > 0
+	value, rest, err := d.readString(rest, 7, usesHuffman)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get name from dynamic table
+	d.mu.Lock()
+	hf, ok := d.dynTable.atRelative(nameIndex)
+	if !ok {
+		d.mu.Unlock()
+		return nil, errInvalidTableIndex
+	}
+	d.dynTable.insert(HeaderField{Name: hf.Name, Value: value})
+	d.mu.Unlock()
+	return rest, nil
+}
+
+func (d *Decoder) processInsertWithoutNameRef(buf []byte) ([]byte, error) {
+	// 01 N xxxxx
+	usesHuffmanName := buf[0]&0x20 > 0
+	name, rest, err := d.readString(buf, 5, usesHuffmanName)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(rest) == 0 {
+		return nil, io.ErrUnexpectedEOF
+	}
+	usesHuffmanValue := rest[0]&0x80 > 0
+	value, rest, err := d.readString(rest, 7, usesHuffmanValue)
+	if err != nil {
+		return nil, err
+	}
+
+	d.mu.Lock()
+	d.dynTable.insert(HeaderField{Name: name, Value: value})
+	d.mu.Unlock()
+	return rest, nil
+}
+
+func (d *Decoder) processSetCapacity(buf []byte) ([]byte, error) {
+	// 001 xxxxx
+	capacity, rest, err := readVarInt(5, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := d.SetDynamicTableCapacity(capacity); err != nil {
+		return nil, err
+	}
+	return rest, nil
+}
+
+func (d *Decoder) processDuplicate(buf []byte) ([]byte, error) {
+	// 000 xxxxx
+	relIndex, rest, err := readVarInt(5, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	d.mu.Lock()
+	hf, ok := d.dynTable.atRelative(relIndex)
+	if !ok {
+		d.mu.Unlock()
+		return nil, errInvalidTableIndex
+	}
+	d.dynTable.insert(hf)
+	d.mu.Unlock()
+	return rest, nil
 }
 
 // Decode returns a function that decodes header fields from the given header block.
@@ -40,29 +322,80 @@ func NewDecoder() *Decoder {
 func (d *Decoder) Decode(p []byte) DecodeFunc {
 	var readRequiredInsertCount bool
 	var readDeltaBase bool
+	var base uint64
+	var requiredInsertCount uint64
 
 	return func() (HeaderField, error) {
 		if !readRequiredInsertCount {
-			requiredInsertCount, rest, err := readVarInt(8, p)
+			encodedInsertCount, rest, err := readVarInt(8, p)
 			if err != nil {
 				return HeaderField{}, err
 			}
 			p = rest
 			readRequiredInsertCount = true
-			if requiredInsertCount != 0 {
-				return HeaderField{}, errors.New("expected Required Insert Count to be zero")
+
+			// Decode Required Insert Count per RFC 9204 Section 4.5.1.1
+			if encodedInsertCount == 0 {
+				requiredInsertCount = 0
+				base = 0
+			} else {
+				d.mu.RLock()
+				insertCount := d.dynTable.insertCount
+				d.mu.RUnlock()
+
+				maxEntries := d.maxTableCapacity / 32
+				if maxEntries == 0 {
+					maxEntries = 1
+				}
+				fullRange := 2 * maxEntries
+				if encodedInsertCount > fullRange {
+					return HeaderField{}, errors.New("invalid encoded insert count")
+				}
+
+				maxValue := insertCount + maxEntries
+				maxWrapped := (maxValue / fullRange) * fullRange
+				requiredInsertCount = maxWrapped + encodedInsertCount - 1
+
+				// Handle wrap-around
+				if requiredInsertCount > maxValue {
+					if requiredInsertCount <= fullRange {
+						return HeaderField{}, errors.New("invalid required insert count")
+					}
+					requiredInsertCount -= fullRange
+				}
+
+				// Check if we have enough entries
+				if requiredInsertCount > insertCount {
+					return HeaderField{}, fmt.Errorf("required insert count %d exceeds current %d", requiredInsertCount, insertCount)
+				}
+
+				base = requiredInsertCount
 			}
 		}
 
 		if !readDeltaBase {
-			base, rest, err := readVarInt(7, p)
+			// Read Sign bit and Delta Base
+			if len(p) == 0 {
+				return HeaderField{}, io.ErrUnexpectedEOF
+			}
+			sign := p[0]&0x80 > 0
+			deltaBase, rest, err := readVarInt(7, p)
 			if err != nil {
 				return HeaderField{}, err
 			}
 			p = rest
 			readDeltaBase = true
-			if base != 0 {
-				return HeaderField{}, errors.New("expected Base to be zero")
+
+			// Calculate base
+			if sign {
+				// Negative: Base = ReqInsertCount - DeltaBase - 1
+				if deltaBase+1 > requiredInsertCount {
+					return HeaderField{}, errors.New("invalid delta base")
+				}
+				base = requiredInsertCount - deltaBase - 1
+			} else {
+				// Positive: Base = ReqInsertCount + DeltaBase
+				base = requiredInsertCount + deltaBase
 			}
 		}
 
@@ -75,12 +408,16 @@ func (d *Decoder) Decode(p []byte) DecodeFunc {
 		var rest []byte
 		var err error
 		switch {
-		case (b & 0x80) > 0: // 1xxxxxxx
-			hf, rest, err = d.parseIndexedHeaderField(p)
-		case (b & 0xc0) == 0x40: // 01xxxxxx
-			hf, rest, err = d.parseLiteralHeaderField(p)
-		case (b & 0xe0) == 0x20: // 001xxxxx
+		case (b & 0x80) > 0: // 1xxxxxxx - Indexed Field Line
+			hf, rest, err = d.parseIndexedHeaderField(p, base)
+		case (b & 0xc0) == 0x40: // 01xxxxxx - Literal Field Line With Name Reference
+			hf, rest, err = d.parseLiteralHeaderField(p, base)
+		case (b & 0xe0) == 0x20: // 001xxxxx - Literal Field Line With Literal Name
 			hf, rest, err = d.parseLiteralHeaderFieldWithoutNameReference(p)
+		case (b & 0xf0) == 0x10: // 0001xxxx - Indexed Field Line With Post-Base Index
+			hf, rest, err = d.parseIndexedFieldLinePostBase(p, base)
+		case (b & 0xf0) == 0x00: // 0000xxxx - Literal Field Line With Post-Base Name Reference
+			hf, rest, err = d.parseLiteralFieldLinePostBase(p, base)
 		default:
 			err = fmt.Errorf("unexpected type byte: %#x", b)
 		}
@@ -92,37 +429,102 @@ func (d *Decoder) Decode(p []byte) DecodeFunc {
 	}
 }
 
-func (d *Decoder) parseIndexedHeaderField(buf []byte) (_ HeaderField, rest []byte, _ error) {
-	if buf[0]&0x40 == 0 {
-		return HeaderField{}, buf, errNoDynamicTable
-	}
+func (d *Decoder) parseIndexedHeaderField(buf []byte, base uint64) (_ HeaderField, rest []byte, _ error) {
+	// 1 T xxxxxx
+	isStatic := buf[0]&0x40 > 0
 	index, rest, err := readVarInt(6, buf)
 	if err != nil {
 		return HeaderField{}, buf, err
 	}
-	hf, ok := d.at(index)
+
+	var hf HeaderField
+	var ok bool
+	if isStatic {
+		hf, ok = d.atStatic(index)
+	} else {
+		// Dynamic table reference (relative to base)
+		d.mu.RLock()
+		absIndex := base - index - 1
+		hf, ok = d.dynTable.atAbsolute(absIndex)
+		d.mu.RUnlock()
+	}
+
 	if !ok {
 		return HeaderField{}, buf, invalidIndexError(index)
 	}
 	return hf, rest, nil
 }
 
-func (d *Decoder) parseLiteralHeaderField(buf []byte) (_ HeaderField, rest []byte, _ error) {
-	if buf[0]&0x10 == 0 {
-		return HeaderField{}, buf, errNoDynamicTable
-	}
-	// We don't need to check the value of the N-bit here.
-	// It's only relevant when re-encoding header fields,
-	// and determines whether the header field can be added to the dynamic table.
-	// Since we don't support the dynamic table, we can ignore it.
+func (d *Decoder) parseIndexedFieldLinePostBase(buf []byte, base uint64) (_ HeaderField, rest []byte, _ error) {
+	// 0001 xxxx - Post-Base Index
 	index, rest, err := readVarInt(4, buf)
 	if err != nil {
 		return HeaderField{}, buf, err
 	}
-	hf, ok := d.at(index)
+
+	d.mu.RLock()
+	hf, ok := d.dynTable.atPostBase(base, index)
+	d.mu.RUnlock()
+
 	if !ok {
 		return HeaderField{}, buf, invalidIndexError(index)
 	}
+	return hf, rest, nil
+}
+
+func (d *Decoder) parseLiteralHeaderField(buf []byte, base uint64) (_ HeaderField, rest []byte, _ error) {
+	// 01 N T xxxx
+	// N = never index, T = static/dynamic
+	isStatic := buf[0]&0x10 > 0
+	index, rest, err := readVarInt(4, buf)
+	if err != nil {
+		return HeaderField{}, buf, err
+	}
+
+	var hf HeaderField
+	var ok bool
+	if isStatic {
+		hf, ok = d.atStatic(index)
+	} else {
+		// Dynamic table reference
+		d.mu.RLock()
+		absIndex := base - index - 1
+		hf, ok = d.dynTable.atAbsolute(absIndex)
+		d.mu.RUnlock()
+	}
+
+	if !ok {
+		return HeaderField{}, buf, invalidIndexError(index)
+	}
+
+	buf = rest
+	if len(buf) == 0 {
+		return HeaderField{}, buf, io.ErrUnexpectedEOF
+	}
+	usesHuffman := buf[0]&0x80 > 0
+	val, rest, err := d.readString(rest, 7, usesHuffman)
+	if err != nil {
+		return HeaderField{}, rest, err
+	}
+	hf.Value = val
+	return hf, rest, nil
+}
+
+func (d *Decoder) parseLiteralFieldLinePostBase(buf []byte, base uint64) (_ HeaderField, rest []byte, _ error) {
+	// 0000 N xxx - Post-Base Name Reference
+	index, rest, err := readVarInt(3, buf)
+	if err != nil {
+		return HeaderField{}, buf, err
+	}
+
+	d.mu.RLock()
+	hf, ok := d.dynTable.atPostBase(base, index)
+	d.mu.RUnlock()
+
+	if !ok {
+		return HeaderField{}, buf, invalidIndexError(index)
+	}
+
 	buf = rest
 	if len(buf) == 0 {
 		return HeaderField{}, buf, io.ErrUnexpectedEOF
@@ -175,7 +577,7 @@ func (d *Decoder) readString(buf []byte, n uint8, usesHuffman bool) (string, []b
 	return val, buf, nil
 }
 
-func (d *Decoder) at(i uint64) (hf HeaderField, ok bool) {
+func (d *Decoder) atStatic(i uint64) (hf HeaderField, ok bool) {
 	if i >= uint64(len(staticTableEntries)) {
 		return
 	}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -22,19 +22,13 @@ func TestDecoderInvalidInputs(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "non-zero required insert count", // we don't support dynamic table updates
-			input:    append(appendVarInt(nil, 8, 1), appendVarInt(nil, 7, 0)...),
-			expected: "expected Required Insert Count to be zero",
-		},
-		{
-			name:     "non-zero delta base", // we don't support dynamic table updates
-			input:    append(appendVarInt(nil, 8, 0), appendVarInt(nil, 7, 1)...),
-			expected: "expected Base to be zero",
-		},
-		{
-			name:     "unknown type byte",
-			input:    insertPrefix([]byte{0x10}),
-			expected: "unexpected type byte: 0x10",
+			name: "invalid static table index",
+			input: func() []byte {
+				data := appendVarInt(nil, 6, 10000)
+				data[0] ^= 0x80 | 0x40
+				return insertPrefix(data)
+			}(),
+			expected: "invalid indexed representation index 10000",
 		},
 	}
 
@@ -131,6 +125,8 @@ var (
 )
 
 func TestDecoderLiteralHeaderFieldDynamicTable(t *testing.T) {
+	// When referencing a dynamic table entry that doesn't exist,
+	// we should get an invalid index error
 	data := appendVarInt(nil, 4, 49)
 	data[0] ^= 0x40 // don't set the static flag (0x10)
 	data = appendVarInt(data, 7, 6)
@@ -138,7 +134,9 @@ func TestDecoderLiteralHeaderFieldDynamicTable(t *testing.T) {
 	dec := NewDecoder()
 	decode := dec.Decode(insertPrefix(data))
 	_, err := decode()
-	require.ErrorIs(t, err, errNoDynamicTable)
+	// With dynamic table support, we get invalid index since the table is empty
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid indexed representation index")
 }
 
 func decodeAll(t *testing.T, decode func() (HeaderField, error)) []HeaderField {
@@ -177,13 +175,13 @@ func TestDecoderInvalidIndexedHeaderFields(t *testing.T) {
 			expected: "invalid indexed representation index 10000",
 		},
 		{
-			name: "rejects an indexed header field that references the dynamic table",
+			name: "errors when a non-existent dynamic table entry is referenced",
 			input: func() []byte {
 				data := appendVarInt(nil, 6, 20)
 				data[0] ^= 0x80 // don't set the static flag (0x40)
 				return insertPrefix(data)
 			}(),
-			expected: errNoDynamicTable.Error(),
+			expected: "invalid indexed representation index 20",
 		},
 	}
 
@@ -259,6 +257,110 @@ func testDecoderEOF(t *testing.T, data []byte, numExpected int) {
 			hfs = append(hfs, hf)
 		}
 	}
+}
+
+// Tests for dynamic table support
+
+func TestDynamicTableBasicOperations(t *testing.T) {
+	dt := newDynamicTable(1024)
+
+	// Insert an entry
+	dt.insert(HeaderField{Name: "foo", Value: "bar"})
+	require.Equal(t, uint64(1), dt.insertCount)
+
+	// Retrieve by relative index
+	hf, ok := dt.atRelative(0)
+	require.True(t, ok)
+	require.Equal(t, "foo", hf.Name)
+	require.Equal(t, "bar", hf.Value)
+
+	// Retrieve by absolute index
+	hf, ok = dt.atAbsolute(0)
+	require.True(t, ok)
+	require.Equal(t, "foo", hf.Name)
+
+	// Insert another entry
+	dt.insert(HeaderField{Name: "baz", Value: "qux"})
+	require.Equal(t, uint64(2), dt.insertCount)
+
+	// New entry is at relative 0, old is at relative 1
+	hf, ok = dt.atRelative(0)
+	require.True(t, ok)
+	require.Equal(t, "baz", hf.Name)
+
+	hf, ok = dt.atRelative(1)
+	require.True(t, ok)
+	require.Equal(t, "foo", hf.Name)
+}
+
+func TestDynamicTableCapacity(t *testing.T) {
+	// Small capacity that can only hold one entry
+	dt := newDynamicTable(64)
+
+	// First entry
+	dt.insert(HeaderField{Name: "a", Value: "b"})
+	require.Equal(t, 1, len(dt.entries))
+
+	// Second entry should evict first
+	dt.insert(HeaderField{Name: "c", Value: "d"})
+	require.Equal(t, 1, len(dt.entries))
+
+	hf, ok := dt.atRelative(0)
+	require.True(t, ok)
+	require.Equal(t, "c", hf.Name)
+}
+
+func TestProcessEncoderInstructions(t *testing.T) {
+	dec := NewDecoderWithCapacity(4096)
+
+	// Build an "Insert Without Name Reference" instruction
+	// 01 N xxxxx - name length, then name, then value length, then value
+	instruction := appendVarInt(nil, 5, 3) // name length 3
+	instruction[0] |= 0x40                 // set the instruction type bit
+	instruction = append(instruction, []byte("foo")...)
+	instruction = appendVarInt(instruction, 7, 3) // value length 3
+	instruction = append(instruction, []byte("bar")...)
+
+	err := dec.ProcessEncoderInstructions(instruction)
+	require.NoError(t, err)
+
+	// Check that the entry was added
+	require.Equal(t, uint64(1), dec.InsertCount())
+}
+
+func TestProcessEncoderInstructionsWithStaticNameRef(t *testing.T) {
+	dec := NewDecoderWithCapacity(4096)
+
+	// Build an "Insert With Name Reference (static)" instruction
+	// 11 xxxxxx - static table index, then value length, then value
+	// Use index 1 which is ":path"
+	instruction := appendVarInt(nil, 6, 1) // index 1
+	instruction[0] |= 0xc0                 // set bits for static name ref
+	instruction = appendVarInt(instruction, 7, 4)
+	instruction = append(instruction, []byte("/foo")...)
+
+	err := dec.ProcessEncoderInstructions(instruction)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(1), dec.InsertCount())
+}
+
+func TestSetDynamicTableCapacity(t *testing.T) {
+	dec := NewDecoderWithCapacity(4096)
+
+	// Build a "Set Dynamic Table Capacity" instruction
+	// 001 xxxxx - capacity
+	instruction := appendVarInt(nil, 5, 1024)
+	instruction[0] |= 0x20
+
+	err := dec.ProcessEncoderInstructions(instruction)
+	require.NoError(t, err)
+
+	// Trying to set capacity above max should fail
+	instruction = appendVarInt(nil, 5, 8192)
+	instruction[0] |= 0x20
+	err = dec.ProcessEncoderInstructions(instruction)
+	require.ErrorIs(t, err, errTableCapacityLimit)
 }
 
 func BenchmarkDecoder(b *testing.B) {


### PR DESCRIPTION
# Add decoder-side dynamic table support

## Summary

This PR adds support for decoding QPACK header blocks that reference the dynamic table, addressing the feature request in #33.

## Motivation

Many HTTP/3 servers (including Google, Cloudflare, and other major implementations) use QPACK dynamic tables to optimize header compression. Without dynamic table support on the decoder side, clients using this library fail to decode responses from these servers with errors like:

```
expected Required Insert Count to be zero
```

This has been reported by multiple users in #33 who encountered issues when their HTTP/3 clients couldn't decode server responses.

## Changes

### New Features
- **Dynamic Table**: Added `dynamicTable` struct with proper FIFO semantics, entry eviction, and support for both relative and absolute indexing
- **Encoder Stream Processing**: Added `ProcessEncoderInstructions()` method to process instructions from the QPACK encoder stream (Insert With Name Reference, Insert Without Name Reference, Set Dynamic Table Capacity, Duplicate)
- **Required Insert Count Decoding**: Updated `Decode()` to properly decode non-zero Required Insert Count per RFC 9204 Section 4.5.1.1
- **All Field Line Types**: Support for all QPACK field line representations including post-base indexed fields and post-base name references
- **Thread Safety**: Added `sync.RWMutex` for safe concurrent access to the dynamic table
- **Configurable Capacity**: Added `NewDecoderWithCapacity()` to configure maximum table capacity

### Backwards Compatibility
- The encoder continues to use only the static table and literal encoding
- Existing code using `NewDecoder()` will work unchanged
- All existing tests pass

## Testing

Added comprehensive tests for:
- Dynamic table basic operations (insert, eviction, lookup)
- Encoder instruction processing
- Capacity limits
- Edge cases with empty/full tables

All existing tests continue to pass.

## Usage

```go
// Create decoder with dynamic table support
dec := qpack.NewDecoderWithCapacity(65536)

// Process encoder stream data (from QPACK encoder stream)
err := dec.ProcessEncoderInstructions(encoderStreamData)

// Decode header blocks as before
decodeFn := dec.Decode(headerBlock)
for {
    hf, err := decodeFn()
    if err == io.EOF {
        break
    }
    // use hf
}
```

## References
- RFC 9204: QPACK - Field Compression for HTTP/3
- Issue #33: Dynamic table support request
