### PR TITLE
ci: run benchmarks using Codspeed

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,6 +2,7 @@ name: Benchmarks
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   push:
@@ -26,4 +27,3 @@ jobs:
         with:
           mode: walltime
           run: go test -run=^$ -bench=. ./...
-          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmarks
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+  # `workflow_dispatch` allows CodSpeed to trigger backtest
+  # performance analysis in order to generate initial data.
+  workflow_dispatch:
+
+jobs:
+  benchmarks:
+    name: Run benchmarks
+    runs-on: codspeed-macro
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.x"
+      - name: Run the benchmarks
+        uses: CodSpeedHQ/action@v4
+        with:
+          mode: walltime
+          run: go test -run=^$ -bench=. ./...
+          token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add CodSpeed benchmark job to CI to run Go benchmarks on push to master, pull requests, and manual dispatch using walltime mode on the codspeed-macro runner
Add a 'Benchmarks' GitHub Actions workflow that checks out code, sets up Go 1.25.x, and runs `CodSpeedHQ/action@v4` with `mode=walltime` executing `go test -run=^$ -bench=. ./...` on the `codspeed-macro` runner.

#### 📍Where to Start
Start with the workflow definition in [benchmark.yml](https://github.com/quic-go/qpack/pull/80/files#diff-aacbd0338bcf598920c120b69adaba2672acc7ea314cfca0f792bebe5fe2acd0).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 9f4564c.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->