### PR TITLE
ci: fix Codspeed build failure

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: codspeed-macro
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - uses: actions/setup-go@v6
         with:
           go-version: "1.25.x"


### PR DESCRIPTION
The build failed because the interop directory was empty (git submodule not checked out).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codspeed benchmark CI failure by fetching Git submodules recursively
> Adds `submodules: recursive` to the `actions/checkout` step in the [benchmark.yml](.github/workflows/benchmark.yml) benchmarks job so that required submodules are present during the build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8a1f86.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->