### PR TITLE
ci: pin Codspeed Go runner version

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,4 +28,6 @@ jobs:
         uses: CodSpeedHQ/action@v4
         with:
           mode: walltime
+          # see https://github.com/CodSpeedHQ/codspeed-go/releases
+          go-runner-version: "1.0.2"
           run: go test -run=^$ -bench=. ./...


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Pin CodSpeed Go runner to version 1.0.2 in benchmark CI workflow
Sets `go-runner-version: "1.0.2"` in the [benchmark.yml](https://github.com/quic-go/qpack/pull/84/files#diff-aacbd0338bcf598920c120b69adaba2672acc7ea314cfca0f792bebe5fe2acd0) CodSpeedHQ action config to ensure reproducible benchmark runs.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52171a1.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->