### PR TITLE
add a seed corpus for the fuzzer

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -9,6 +9,57 @@ import (
 )
 
 func FuzzDecode(f *testing.F) {
+	for _, headerFields := range [][]HeaderField{
+		{ // simple GET request: all indexed fields
+			{Name: ":method", Value: "GET"},
+			{Name: ":scheme", Value: "https"},
+			{Name: ":path", Value: "/"},
+			{Name: ":authority", Value: "example.com"},
+			{Name: "accept", Value: "*/*"},
+			{Name: "accept-encoding", Value: "gzip, deflate, br"},
+		},
+		{ // POST with JSON body: indexed + literal with name reference
+			{Name: ":method", Value: "POST"},
+			{Name: ":scheme", Value: "https"},
+			{Name: ":path", Value: "/api/v1/users"},
+			{Name: ":authority", Value: "api.example.com"},
+			{Name: "content-type", Value: "application/json"},
+			{Name: "content-length", Value: "128"},
+			{Name: "accept", Value: "application/json"},
+		},
+		{ // response with common headers
+			{Name: ":status", Value: "200"},
+			{Name: "content-type", Value: "text/html; charset=utf-8"},
+			{Name: "content-encoding", Value: "gzip"},
+			{Name: "vary", Value: "accept-encoding"},
+			{Name: "cache-control", Value: "no-cache"},
+			{Name: "strict-transport-security", Value: "max-age=31536000; includesubdomains; preload"},
+		},
+		{ // custom headers: literal without name reference (Huffman-encoded)
+			{Name: ":method", Value: "GET"},
+			{Name: ":scheme", Value: "https"},
+			{Name: ":path", Value: "/"},
+			{Name: "x-request-id", Value: "a]cef9-1234-5678"},
+			{Name: "x-trace-id", Value: "trace-98765"},
+			{Name: "user-agent", Value: "Mozilla/5.0 (X11; Linux x86_64)"},
+		},
+		{ // 404 response: indexed status + name-referenced values not in static table
+			{Name: ":status", Value: "404"},
+			{Name: "content-type", Value: "text/plain"},
+			{Name: "server", Value: "custom-server/1.0"},
+			{Name: "date", Value: "Mon, 01 Jan 2024 00:00:00 GMT"},
+			{Name: "x-error-code", Value: "NOT_FOUND"},
+		},
+	} {
+		buf := &bytes.Buffer{}
+		encoder := NewEncoder(buf)
+		for _, hf := range headerFields {
+			require.NoError(f, encoder.WriteField(hf))
+		}
+		require.NoError(f, encoder.Close())
+		f.Add(buf.Bytes())
+	}
+
 	f.Fuzz(func(t *testing.T, data []byte) {
 		decoder := NewDecoder()
 		decode := decoder.Decode(data)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add seed corpus to `FuzzDecode` fuzz test
Seeds the fuzz corpus in [fuzz_test.go](https://github.com/quic-go/qpack/pull/85/files#diff-4a0954693dd52efba878ef592132c50fa85c54acfb61641e79fe080df92a072b) with five representative HPACK-encoded header blocks before fuzzing begins. The seeds cover a GET request, a POST with JSON headers, a 200 response, a request with custom literal headers, and a 404 response — each encoded via `NewEncoder` into a `bytes.Buffer` and registered with `f.Add`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47bd204.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->