### PR TITLE
ci: run ClusterFuzzLite in batch mode

### DIFF
--- a/.github/workflows/clusterfuzz-lite-batch.yml
+++ b/.github/workflows/clusterfuzz-lite-batch.yml
@@ -1,0 +1,36 @@
+name: ClusterFuzzLite batch fuzzing
+on:
+  schedule:
+    - cron: '0 0/6 * * *'
+  pull_request: # TODO: remove
+    paths:
+      - "**"
+permissions: read-all
+
+jobs:
+  BatchFuzzing:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer:
+        - address
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: go
+        sanitizer: ${{ matrix.sanitizer }}
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 300 # TODO: increase
+        mode: 'batch'
+        sanitizer: ${{ matrix.sanitizer }}
+        output-sarif: true
+        storage-repo: https://${{ secrets.CLUSTERFUZZ_LITE_STORAGE }}@github.com/quic-go/clusterfuzzlite-storage.git
+        storage-repo-branch: master
+        storage-repo-branch-coverage: gh-pages


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add ClusterFuzzLite batch fuzzing workflow to CI
Adds [clusterfuzz-lite-batch.yml](.github/clusterfuzz-lite-batch.yml), a GitHub Actions workflow that builds Go fuzzers with address sanitizer and runs them in batch mode for 300 seconds. The workflow triggers on a cron schedule every 6 hours and on pull requests, emits SARIF output, and syncs artifacts to a configured storage repository via secrets.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12bd7e0. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->