### PR TITLE
ci: run go fix as part of the lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,11 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
+      - name: Run go fix
+        if: (success() || failure()) && matrix.go == '1.25.x'
+        run: go fix -diff ./...
       - name: golangci-lint
+        if: success() || failure() # run this step even if the previous one failed
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.4.0

--- a/qpack_test.go
+++ b/qpack_test.go
@@ -41,15 +41,11 @@ func TestEncodeDecode(t *testing.T) {
 // replace one character by a random character at a random position
 func replaceRandomCharacter(s string) string {
 	pos := rand.IntN(len(s))
-	new := s[:pos]
 	for {
-		if c := randomString(1); c != string(s[pos]) {
-			new += c
-			break
+		if c := randomString(1); c != s[pos:pos+1] {
+			return s[:pos] + c + s[pos+1:]
 		}
 	}
-	new += s[pos+1:]
-	return new
 }
 
 func check(t *testing.T, encoded []byte, hf HeaderField) {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Run `go fix -diff` as part of the lint workflow
- Adds a new step in [lint.yml](.github/workflows/lint.yml) that runs `go fix -diff ./...` for Go 1.25.x, surfacing any fixes suggested by the current Go toolchain.
- Updates `qpack_test.go` to apply `go fix` changes to the `replaceRandomCharacter` helper, replacing intermediate variable usage with direct slice concatenation.
- The `golangci-lint` step is updated with `if: success() || failure()` so it still runs even when the `go fix` step fails.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05f5846.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->